### PR TITLE
Add Gnome 40 support

### DIFF
--- a/unredirect@vaina.lt/metadata.json
+++ b/unredirect@vaina.lt/metadata.json
@@ -13,7 +13,8 @@
       "3.30",
       "3.32",
       "3.36",
-      "3.38"
+      "3.38",
+      "3.40"
    ],
    "uuid":"unredirect@vaina.lt",
    "name":"Disable unredirect fullscreen windows",


### PR DESCRIPTION
Note: This was a blind guess, but I think the change is straight forward. Do you know if there is a way to specify that version as a wildcard?

Edit: I want to add, that is might be possible that the new version is 40, not 3.40. I am not sure.

FYI: I've opened an issue with that question here: https://gitlab.gnome.org/ewlsh/gjs-guide/-/issues/13