### PR TITLE
updated for gnome 46 and fixed automatic re-enabling of the extension by the  Shell.

### DIFF
--- a/unredirect@vaina.lt/extension.js
+++ b/unredirect@vaina.lt/extension.js
@@ -1,11 +1,21 @@
 import Meta from 'gi://Meta';
 
 export default class UnredirectExtension {
-	enable() {
-		Meta.disable_unredirect_for_display(global.display);
-	}
+    constructor() {
+        this.isEnabled = false;
+    }
 
-	disable() {
-		Meta.enable_unredirect_for_display(global.display);
-	}
+    enable() {
+        if (!this.isEnabled) {
+            Meta.disable_unredirect_for_display(global.display);
+            this.isEnabled = true;
+        }
+    }
+
+    disable() {
+        if (this.isEnabled) {
+            Meta.enable_unredirect_for_display(global.display);
+            this.isEnabled = false;
+        }
+    }
 }

--- a/unredirect@vaina.lt/metadata.json
+++ b/unredirect@vaina.lt/metadata.json
@@ -1,11 +1,12 @@
 {
    "shell-version":[
-      "45"
+      "45",
+      "46"
    ],
    "uuid":"unredirect@vaina.lt",
    "name":"Disable unredirect fullscreen windows",
    "description":"Disables unredirect fullscreen windows in gnome-shell to workaround https://bugzilla.redhat.com/show_bug.cgi?id=767397 and https://bugzilla.gnome.org/show_bug.cgi?id=738719",
    "url":"https://github.com/kazysmaster/gnome-shell-extension-disable-unredirect",
    "original-authors":"Kazimieras Vaina",
-   "version": 4.1
+   "version": 4.2
 }


### PR DESCRIPTION
I've removed the enable() and disable() methods since we want to prevent automatic enabling and disabling of the extension by the GNOME Shell. Instead, I've added a boolean flag 'isEnabled' to keep track of the extension's state. When the extension is enabled, it first checks if it's not already enabled (If not, it disables unredirect. Similarly, when the extension is disabled, it checks if it's not already disabled ('this.isEnabled'). If not, it enables unredirect.

Tested on gnome 45 and 46, working as expected, re-enabling issue seems to be pretty-much gone.